### PR TITLE
Fix Avaiable typos

### DIFF
--- a/efr-plugins/efr-motorgo/README.md
+++ b/efr-plugins/efr-motorgo/README.md
@@ -8,13 +8,13 @@
 
 - [MotorGo Plugin for efr](#motorgo-plugin-for-efr)
   - [Table of Contents](#table-of-contents)
-  - [Avaiable Commands](#avaiable-commands)
+  - [Available Commands](#avaiable-commands)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
 
 ---
 
-## Avaiable Commands
+## Available Commands
 
 - **boards**: Utilities for handling custom MotorGo board definitions.
   - **install**: Installs a custom board definition and variant for PlatformIO.

--- a/efr-plugins/efr-plugins/README.md
+++ b/efr-plugins/efr-plugins/README.md
@@ -8,13 +8,13 @@
 
 - [MotorGo Plugin for efr](#motorgo-plugin-for-efr)
   - [Table of Contents](#table-of-contents)
-  - [Avaiable Commands](#avaiable-commands)
+  - [Available Commands](#avaiable-commands)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
 
 ---
 
-## Avaiable Commands
+## Available Commands
 
 - **boards**: Utilities for handling custom MotorGo board definitions.
   - **install**: Installs a custom board definition and variant for PlatformIO.

--- a/efr-plugins/efr-plugins/plugins/templates/README.md.template
+++ b/efr-plugins/efr-plugins/plugins/templates/README.md.template
@@ -8,13 +8,13 @@
 
 - [{name} Plugin for efr CLI](#{name}-plugin-for-efr)
   - [Table of Contents](#table-of-contents)
-  - [Avaiable Commands](#avaiable-commands)
+  - [Available Commands](#avaiable-commands)
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
 
 ---
 
-## Avaiable Commands
+## Available Commands
 
 
 ---


### PR DESCRIPTION
## Summary
- fix all occurrences of the typo "Avaiable" in plugin docs

## Testing
- `grep -R "Avaiable" -n`


------
https://chatgpt.com/codex/tasks/task_e_68557fd4fcec832c83a5704f96a5d531