### PR TITLE
Update registry for cross-platform installs

### DIFF
--- a/efr-plugins/efr-plugins/plugins/plugin_registry.json
+++ b/efr-plugins/efr-plugins/plugins/plugin_registry.json
@@ -1,18 +1,18 @@
 {
     "plugins": {
         "description": "Utilites for managing plugins for `efr` CLI",
-        "install_url": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-plugins/install.sh"
+        "install_script_base": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-plugins/install"
     },
     "motorgo": {
         "description": "Common utilities for MotorGo development",
-        "install_url": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-motorgo/install.sh"
+        "install_script_base": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-motorgo/install"
     },
     "gh": {
         "description": "Convenience tools for interacting with efr gh repos.",
-        "install_url": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-gh/install.sh"
+        "install_script_base": "https://raw.githubusercontent.com/Every-Flavor-Robotics/efr/refs/heads/main/efr-plugins/efr-gh/install"
     },
     "joybridge": {
         "description": "Use an ESP32-S3 as an ESP-NOW transponder to relay joystick input.",
-        "install_url": "https://raw.githubusercontent.com/Every-Flavor-Robotics/esp-now-joybridge/refs/heads/main/joybridge_host/install.sh"
+        "install_script_base": "https://raw.githubusercontent.com/Every-Flavor-Robotics/esp-now-joybridge/refs/heads/main/joybridge_host/install"
     }
 }


### PR DESCRIPTION
## Summary
- add `install_script_base` to plugin registry
- update `efr plugins` registry commands to output and use the base URL
- support `.sh` and `.ps1` installers based on OS

## Testing
- `python -m py_compile efr-plugins/efr-plugins/plugins/cli.py`
- `python -m py_compile efr-plugins/efr-plugins/plugins/plugin_utils.py`
- `python -m py_compile efr/cli.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685580f82878832c91bd1610bef9b6db