### PR TITLE
updated cli to use importlib.metadata instead of pgk_resources 

### DIFF
--- a/efr-plugins/efr-motorgo/install.sh
+++ b/efr-plugins/efr-motorgo/install.sh
@@ -31,8 +31,8 @@ git pull origin main --depth=1
 cd "${PLUGIN_SUBDIR}"
 
 # 8) Install the plugin (non-editable mode, upgrade pip if desired)
-pip install --upgrade pip
-pip install .
+python3 -m pip install --upgrade pip
+python3 -m pip install .
 
 echo "==> Plugin efr-motorgo successfully installed!"
 

--- a/efr-plugins/efr-plugins/plugins/cli.py
+++ b/efr-plugins/efr-plugins/plugins/cli.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 import click
-import pkg_resources
 import requests
+from importlib.metadata import distributions
 
 from plugins import plugin_utils
 
@@ -176,9 +176,7 @@ def list_plugins():
     # so adapt to your real JSON structure.
 
     # Gather installed package names (lowercased) for easy membership checking
-    installed_packages = {
-        dist.project_name.lower() for dist in pkg_resources.working_set
-    }
+    installed_packages = {dist.metadata["Name"].lower() for dist in distributions()}
 
     installed_list = []
     uninstalled_list = []

--- a/efr-plugins/efr-plugins/plugins/plugin_utils.py
+++ b/efr-plugins/efr-plugins/plugins/plugin_utils.py
@@ -4,8 +4,8 @@ import subprocess
 from pathlib import Path
 
 import click
-import pkg_resources
 import requests
+from importlib.metadata import distributions
 import tomllib
 
 REGISTRY_URL = (
@@ -355,8 +355,6 @@ def is_plugin_installed(plugin_name: str) -> bool:
     """
     Checks if the plugin (assuming PyPI package named 'efr-{plugin_name}') is installed.
     """
-    installed_packages = {
-        dist.project_name.lower() for dist in pkg_resources.working_set
-    }
+    installed_packages = {dist.metadata["Name"].lower() for dist in distributions()}
     candidate_name = f"efr-{plugin_name}".lower()
     return candidate_name in installed_packages

--- a/efr/cli.py
+++ b/efr/cli.py
@@ -1,11 +1,10 @@
 # efr/cli.py
 import click
-import pkg_resources
 import os
 from pathlib import Path
 import platform
 import subprocess
-
+from importlib.metadata import version, entry_points, PackageNotFoundError
 
 def get_version():
     """
@@ -13,9 +12,8 @@ def get_version():
     Fallback to "unknown" if not found.
     """
     try:
-        dist = pkg_resources.get_distribution("efr")
-        return dist.version
-    except pkg_resources.DistributionNotFound:
+        return version("efr")
+    except PackageNotFoundError:
         return "unknown"
 
 
@@ -46,7 +44,7 @@ def cli(ctx):
 
         # Installed plugins
         click.secho("Installed plugins:", fg="bright_magenta", bold=True)
-        plugin_list = list(pkg_resources.iter_entry_points("efr.plugins"))
+        plugin_list = list(entry_points(group="efr.plugins"))
         if plugin_list:
             for entry_point in plugin_list:
                 click.echo(f"  • {entry_point.name}")
@@ -104,6 +102,6 @@ def upgrade():
 
 
 # Auto-discover plugins: each plugin is a Click command or group
-for entry_point in pkg_resources.iter_entry_points("efr.plugins"):
+for entry_point in entry_points(group="efr.plugins"):
     plugin = entry_point.load()
     cli.add_command(plugin)

--- a/efr/cli.py
+++ b/efr/cli.py
@@ -24,7 +24,7 @@ def cli(ctx):
     efr - A central CLI for bundling modules from different projects.
     """
     if not ctx.invoked_subcommand:
-        version = get_version()
+        efr_version = get_version()
 
         # Title line
         click.secho(
@@ -34,7 +34,7 @@ def cli(ctx):
         )
 
         # Version line
-        click.secho(f"Version: {version}\n", fg="green", bold=True)
+        click.secho(f"Version: {efr_version}\n", fg="green", bold=True)
 
         # Description
         click.secho(


### PR DESCRIPTION
I had an issue installing this in WSL2!  

But the fix suggested by GLM 5 and then Gemini 3 was to use importlib.metadata instead of pgk_resources because it was more "modern" python way of doing it.  Conveniently it also fixes install on WSL2 on Windows.

Curious what you think.